### PR TITLE
Add the new Quinmars.AsyncObservable benchmark

### DIFF
--- a/netcoreapp21/Program.cs
+++ b/netcoreapp21/Program.cs
@@ -12,6 +12,7 @@ namespace akarnokd_misc_dotnet
             Console.WriteLine(GetNetCoreVersion());
 
             BenchmarkRunner.Run<ShakespearePlaysScrabbleAsyncEnumerableDotNet>();
+            BenchmarkRunner.Run<ShakespearePlaysScrabbleAsyncObservable>();
 
             //BenchmarkRunner.Run<ShakespearePlaysScrabbleRxNET>();
             /*

--- a/netcoreapp21/ShakespearePlaysScrabbleAsyncObservable.cs
+++ b/netcoreapp21/ShakespearePlaysScrabbleAsyncObservable.cs
@@ -1,0 +1,129 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Quinmars;
+using Quinmars.AsyncObservable;
+
+namespace akarnokd_misc_dotnet
+{
+    [MemoryDiagnoser]
+    public class ShakespearePlaysScrabbleAsyncObservable : ShakespearePlaysScrabble
+    {
+        [Benchmark]
+        public object AsyncObs()
+        {
+            return Run();
+        }
+
+        static IAsyncObservable<int> chars(string word)
+        {
+            return AsyncObservable.Range(0, word.Length).Select(i => (int)word[i]);
+        }
+
+        internal static IList<KeyValuePair<int, IList<string>>> Run()
+        {
+            Func<int, int> scoreOfALetter = letter => letterScores[letter - 'a'];
+
+            Func<KeyValuePair<int, MutableInt>, int> letterScore = entry =>
+                letterScores[entry.Key - 'a']
+                * Math.Min(entry.Value.value, scrabbleAvailableLetters[entry.Key - 'a']);
+
+            Func<string, IAsyncObservable<int>> toIntegerFlux = str => chars(str);
+
+            Func<string, IAsyncObservable<Dictionary<int, MutableInt>>> histoOfLetters =
+                word => toIntegerFlux(word)
+                        .Aggregate(
+                            () => new Dictionary<int, MutableInt>(),
+                            (m, value) =>
+                            {
+                                if (!m.TryGetValue(value, out var mi))
+                                { 
+                                    mi = new MutableInt();
+                                    m.Add(value, mi);
+                                }
+
+                                mi.value++;
+                                return m;
+                            }
+                        );
+
+            Func<KeyValuePair<int, MutableInt>, long> blank = entry =>
+                Math.Max(0L, entry.Value.value - scrabbleAvailableLetters[entry.Key - 'a']);
+
+            Func<string, IAsyncObservable<long>> nBlanks = word =>
+                histoOfLetters(word)
+                .SelectMany(map => map.AsEnumerable())
+                .Select(blank)
+                .Aggregate(() => 0L, (x, y) => x + y);
+
+            Func<string, IAsyncObservable<bool>> checkBlanks = word =>
+                nBlanks(word).Select(v => v <= 2);
+
+            Func<string, IAsyncObservable<int>> score2 = word =>
+                histoOfLetters(word)
+                .SelectMany(map => map.AsEnumerable())
+                .Select(letterScore)
+                .Sum();
+
+            Func<string, IAsyncObservable<int>> first3 = word =>
+                chars(word).Take(3);
+
+            Func<string, IAsyncObservable<int>> last3 = word =>
+                chars(word).Skip(3);
+
+            Func<string, IAsyncObservable<int>> toBeMaxed = word =>
+                AsyncObservable.Concat(first3(word), last3(word));
+
+            Func<string, IAsyncObservable<int>> bonusForDoubleLetter = word =>
+                toBeMaxed(word)
+                .Select(scoreOfALetter)
+                .Max();
+
+            Func<string, IAsyncObservable<int>> score3 = word =>
+                AsyncObservable.Concat(
+                    score2(word).Select(v => v * 2),
+                    bonusForDoubleLetter(word).Select(v => v * 2),
+                    AsyncObservable.Return(word.Length == 7 ? 50 : 0)
+                )
+                .Sum();
+
+            Func<Func<string, IAsyncObservable<int>>, IAsyncObservable<SortedDictionary<int, IList<string>>>> buildHistoOnScore = score =>
+                shakespeareWords.ToAsyncObservable()
+                .Where(word => scrabbleWords.Contains(word))
+                .Where(word => checkBlanks(word).FirstAsync())
+                .Aggregate(
+                    () => new SortedDictionary<int, IList<string>>(IntReverse),
+                    (map, word) =>
+                    {
+                        int key = score(word).FirstAsync().Result;
+                        if (!map.TryGetValue(key, out var list))
+                        {
+                            list = new List<string>();
+                            map.Add(key, list);
+                        }
+                        list.Add(word);
+                        return map;
+                    }
+                );
+
+            IList<KeyValuePair<int, IList<string>>> finalList2 =
+                buildHistoOnScore(score3)
+                .SelectMany(map => map.AsEnumerable())
+                .Take(3)
+                .Aggregate(
+                    () => new List<KeyValuePair<int, IList<string>>>(),
+                    (list, entry) =>
+                    {
+                        list.Add(entry);
+                        return list;
+                    }
+                )
+                .FirstAsync().Result;
+
+            return finalList2;
+        }
+    }
+}

--- a/netcoreapp21/netcoreapp21.csproj
+++ b/netcoreapp21/netcoreapp21.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="akarnokd.async-enumerable-dotnet" Version="0.0.1.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
+    <PackageReference Include="Quinmars.AsyncObservable" Version="0.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add a benchmark for https://github.com/quinmars/AsyncObservable

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.407 (1803/April2018Update/Redstone4)
Intel Core i5-5200U CPU 2.20GHz (Max: 0.50GHz) (Broadwell), 1 CPU, 4 logical and 2 physical cores
Frequency=2143476 Hz, Resolution=466.5319 ns, Timer=TSC
.NET Core SDK=2.1.403
  [Host]     : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.5 (CoreCLR 4.6.26919.02, CoreFX 4.6.26919.02), 64bit RyuJIT


```
|                Method |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Allocated |
|---------------------- |---------:|---------:|---------:|-----------:|----------:|----------:|
| AsyncEnumerableDotNet | 186.3 ms | 2.035 ms | 1.699 ms | 33000.0000 | 1000.0000 |  51.07 MB |
| AsyncObs              | 139.6 ms | 2.701 ms | 2.256 ms | 37000.0000 | 1000.0000 |  56.42 MB |